### PR TITLE
[U] Use deque to limit the length of the conversation history.

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,13 +5,14 @@ import vlc
 import os 
 import time
 import nltk
+from collections import deque
 
 
 CONVERSATION_LIMIT = 20
 
 class Bot(commands.Bot):
 
-    conversation = list()
+    conversation = deque(maxlen=CONVERSATION_LIMIT)
 
     def __init__(self):
         # Initialise our Bot with our access token, prefix and a list of channels to join on boot...
@@ -56,9 +57,6 @@ class Bot(commands.Bot):
         if(Bot.conversation.count({ 'role': 'assistant', 'content': response }) == 0):
             Bot.conversation.append({ 'role': 'assistant', 'content': response })
         
-        if len(Bot.conversation) > CONVERSATION_LIMIT:
-            Bot.conversation = Bot.conversation[1:]
-        
         client = texttospeech.TextToSpeechClient()
 
         response = message.content + "? " + response
@@ -89,7 +87,6 @@ class Bot(commands.Bot):
         response = client.synthesize_speech(
             request={"input": input_text, "voice": voice, "audio_config": audio_config, "enable_time_pointing": ["SSML_MARK"]}
         )
-
 
         # The response's audio_content is binary.
         with open("output.mp3", "wb") as out:


### PR DESCRIPTION
Optimize the data structure of conversation. 
Since we need to set the max length of the array, we should use the `deque` instead of the `list`.